### PR TITLE
Improved agent email retrieval query

### DIFF
--- a/LanAlert/LanAlertMain.py
+++ b/LanAlert/LanAlertMain.py
@@ -123,10 +123,10 @@ notequery = '''SELECT TOP %s
 agentquery = '''SELECT  
             htblagents.agentid, 
             htblagents.userid, 
-            tblADusers.email
+            htblusers.email
             FROM [lansweeperdb].[dbo].[htblagents]  
-            LEFT JOIN htblusers on htblusers.userid = htblagents.userid  
-            LEFT JOIN tblADusers on htblusers.username = tblADusers.Username  
+            INNER JOIN htblusers on htblusers.userid = htblagents.userid  
+            LEFT JOIN tblADusers on htblusers.username = tblADusers.Username
             WHERE active = 1'''
 slackid = {}
 agenttouser = {}


### PR DESCRIPTION
Change the email retrieval query to pull the email address from helpdesk users instead of AD users. This ensures that if users have their email set in Lansweeper, but not in AD (or do not have an AD) can be correctly linked.